### PR TITLE
LIBFCREPO-1037. Updates to support Docker-based imports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3.7"
 services:
   plastrond:
     image: docker.lib.umd.edu/plastrond
+    ports:
+      - 5000:5000
     configs:
       - source: plastrond
         target: /etc/plastrond.yml

--- a/docker-plastron.yml
+++ b/docker-plastron.yml
@@ -12,6 +12,7 @@ MESSAGE_BROKER:
     JOB_PROGRESS: /topic/plastron.jobs.progress
     JOB_STATUS: /queue/plastron.jobs.status
     SYNCHRONOUS_JOBS: /queue/plastron.jobs.synchronous
+    REINDEXING: /queue/reindex
 COMMANDS:
   EXPORT:
     SSH_PRIVATE_KEY: /etc/plastron/auth/archelon_id


### PR DESCRIPTION
Added "REINDEXING" endpoint to "docker-plastron.yml" to enable
Solr reindexing to function in Docker.

Exposed port 5000 in plastrond Docker container to support new
HTTP endpoint for accessing import status.

https://issues.umd.edu/browse/LIBFCREPO-1037