### PR TITLE
LIBFCREPO-1043. Correct JOBS_DIR configuration location in HTTPDaemon

### DIFF
--- a/docker-plastron-template.yml
+++ b/docker-plastron-template.yml
@@ -4,7 +4,6 @@ REPOSITORY:
   RELPATH: /pcdm
   JWT_SECRET: <REPLACE WITH JWT_SECRET FROM umd-fcrepo>
   LOG_DIR: /var/log/plastron
-  JOBS_DIR: /var/opt/plastron/jobs
 MESSAGE_BROKER:
   SERVER: activemq:61613
   MESSAGE_STORE_DIR: /var/opt/plastron/msg/export
@@ -19,3 +18,4 @@ COMMANDS:
     SSH_PRIVATE_KEY: /etc/plastron/auth/archelon_id
   IMPORT:
     SSH_PRIVATE_KEY: /etc/plastron/auth/archelon_id
+    JOBS_DIR: /var/opt/plastron/jobs

--- a/plastron/daemon.py
+++ b/plastron/daemon.py
@@ -112,8 +112,7 @@ class STOMPDaemon(Thread):
 class HTTPDaemon(Thread):
     def __init__(self, config=None, **kwargs):
         super().__init__(daemon=True, **kwargs)
-        repo_config = config['REPOSITORY']
-        self.jobs_dir = repo_config.get('JOBS_DIR', 'jobs')
+        self.jobs_dir = config.get('COMMANDS', {}).get('IMPORT', {}).get('JOBS_DIR', 'jobs')
         server_config = config.get('HTTP_SERVER', {})
         self.host = server_config.get('HOST', '0.0.0.0')
         self.port = int(server_config.get('PORT', 5000))


### PR DESCRIPTION
Modified the HTTPDaemon class to retrieve the "JOBS_DIR" configuration
from underneath "COMMANDS/IMPORT", instead of "REPOSITORY".

The "docs/import.md" file indicates that "JOBS_DIR" should be in
the "COMMANDS/IMPORT" subsection.

Updated the "docker-plastron-template.yml" file to put the "JOBS_DIR"
setting in the "COMMANDS/IMPORT" subsection.

https://issues.umd.edu/browse/LIBFCREPO-1043